### PR TITLE
fix(#3) Ensure that anonymous images are also included

### DIFF
--- a/test-dir/anon-img.md
+++ b/test-dir/anon-img.md
@@ -1,0 +1,5 @@
+# What properties must a red-black tree satisfy?
+
+![](./assets/05-rbts/rbt-rotation-2.png)
+
+![This should be a figure](./assets/05-rbts/rbt-rotation-2.png)


### PR DESCRIPTION
This ensure that images which don't have alt-text are also included. For
example:

```
![](<path/to/image>)
```

will be included.
