### PR TITLE
Prevent Pandoc warnings from prinint in the compiled binary

### DIFF
--- a/app/Render.hs
+++ b/app/Render.hs
@@ -29,14 +29,15 @@ documenttizeDeck document =
 writeFlashCardHtml :: Pandoc -> IO T.Text
 writeFlashCardHtml p = do
   runIOorExplode $
-    writeHtml5LazyString
-      ( def
-          { writerExtensions = pandocExtensions,
-            writerHTMLMathMethod = MathJax defaultMathJaxURL,
-            writerTemplate = Nothing
-          }
-      )
-      p
+    setVerbosity INFO
+      *> writeHtml5LazyString
+        ( def
+            { writerExtensions = pandocExtensions,
+              writerHTMLMathMethod = MathJax defaultMathJaxURL,
+              writerTemplate = Nothing
+            }
+        )
+        p
   where
     writeHtml5LazyString wopts doc = T.fromStrict <$> writeHtml5String wopts doc
 


### PR DESCRIPTION
Currently, the compiled binaries print these really annoying pandoc loggin
messaged. This PR hopefully stops them but I can only tell once I download one
of the new compiled binaries.
