### PR TITLE
Add front and back html template overrides

### DIFF
--- a/app/Collection/Generate.hs
+++ b/app/Collection/Generate.hs
@@ -5,14 +5,16 @@ module Collection.Generate where
 
 import Codec.Archive.Zip
 import Collection.Utils (genNoteGuid, removeIfExists)
-import Control.Monad.State (MonadIO(liftIO), gets, StateT(runStateT))
+import Control.Monad (join)
+import Control.Monad.State (MonadIO (liftIO), StateT (runStateT), gets)
 import Data.Aeson (decode, decodeStrictText, encode)
 import Data.Aeson.Key qualified as AK (fromString, toString)
-import Data.Aeson.KeyMap qualified as AKM (fromList, insert, keys)
+import Data.Aeson.KeyMap qualified as AKM (elems, fromList, insert, keys)
 import Data.Aeson.Text (encodeToLazyText)
 import Data.Bifunctor (second)
-import Data.ByteString.Lazy qualified as BL
+import Data.Bifunctor.Compat (bimap)
 import Data.ByteString qualified as BS
+import Data.ByteString.Lazy qualified as BL
 import Data.Char (chr)
 import Data.FileEmbed (embedDir, embedFile)
 import Data.Functor (($>))
@@ -22,17 +24,44 @@ import Data.Text.Lazy.Encoding qualified as TE
 import Data.Time.Clock.POSIX
 import Database.SQLite.Simple
 import System.FilePath ((</>))
-import Types (DeckGenInfo (..), MediaDeck, MediaItem (DeckMedia), PankyDeck, RenderedCard (RCard), RenderedDeck, PankyApp)
+import System.IO (IOMode (ReadMode), withBinaryFile)
+import Types (DeckGenInfo (..), MediaDeck, MediaItem (DeckMedia), PankyApp, PankyDeck, RenderedCard (RCard), RenderedDeck)
 import Types.Anki.JSON (Deck (..), Decks, MConf (..), Model (..), Models, Template (..))
 import Types.Anki.SQL as ANS
+import Types.CLI (PankyConfig (backTemplateHtmlsPConf, cssExtendPConf, cssOverridePConf, fontTemplateHtmlsPConf, outputDirPConf))
 import Utils (todo)
-import System.IO (withBinaryFile, IOMode (ReadMode))
-import Types.CLI (PankyConfig(outputDirPConf, cssOverridePConf, cssExtendPConf, fontTemplateHtmlsPConf, backTemplateHtmlsPConf))
-import Data.Bifunctor.Compat (bimap)
-import Control.Monad (join)
 
-addCard :: Int -> Connection -> RenderedCard -> PankyDeck ()
-addCard modelId conn (RCard front back tags) = do
+addCard :: Int -> Int -> Connection -> PankyDeck ()
+addCard noteId templateOrd conn = do
+  cardId <- liftIO $ floor . (* 10000) <$> getPOSIXTime
+  dId <- gets deckId
+  liftIO $
+    execute
+      conn
+      "INSERT INTO cards VALUES(?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)"
+      ANS.Card
+        { idCard = cardId,
+          nidCard = noteId,
+          didCard = dId,
+          ordCard = templateOrd,
+          modCard = cardId `div` 10000, -- time the card was modified
+          usnCard = -1,
+          typeCard = 0,
+          queueCard = 0,
+          dueCard = 0,
+          ivlCard = 0,
+          factorCard = 0,
+          repsCard = 0,
+          lapsesCard = 0,
+          leftCard = 0,
+          odueCard = 0,
+          odidCard = 0,
+          flagsCard = 0,
+          dataCard = ""
+        }
+
+addNote :: Int -> Connection -> RenderedCard -> PankyDeck (Int)
+addNote modelId conn (RCard front back tags) = do
   noteGUID <- gets ((\dn -> genNoteGuid (T.unpack dn) (T.unpack front) []) . deckName)
 
   -- technically these should be miliseconds but its not fast enought
@@ -54,33 +83,7 @@ addCard modelId conn (RCard front back tags) = do
           flagsNote = 0,
           dataNote = ""
         }
-
-  cardId <- liftIO $ floor . (* 10000) <$> getPOSIXTime
-  dId <- gets deckId
-  liftIO $
-    execute
-      conn
-      "INSERT INTO cards VALUES(?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)"
-      ANS.Card
-        { idCard = cardId,
-          nidCard = noteId,
-          didCard = dId,
-          ordCard = 0,
-          modCard = cardId `div` 10000, -- time the card was modified
-          usnCard = -1,
-          typeCard = 0,
-          queueCard = 0,
-          dueCard = 0,
-          ivlCard = 0,
-          factorCard = 0,
-          repsCard = 0,
-          lapsesCard = 0,
-          leftCard = 0,
-          odueCard = 0,
-          odidCard = 0,
-          flagsCard = 0,
-          dataCard = ""
-        }
+  return noteId
 
 setupCollectionDb :: Connection -> PankyApp [Int]
 setupCollectionDb conn = do
@@ -100,8 +103,10 @@ setupCollectionDb conn = do
 
   overrideCss <- gets cssOverridePConf
   extendCss <- gets cssExtendPConf
-  let cardCSS = (if overrideCss /= "" then overrideCss else TE.decodeUtf8 (fromJust $ lookup "css/card.css" dataFiles))
-                  <> "\n" <> extendCss
+  let cardCSS =
+        (if overrideCss /= "" then overrideCss else TE.decodeUtf8 (fromJust $ lookup "css/card.css" dataFiles))
+          <> "\n"
+          <> extendCss
 
   currTime <- liftIO getPOSIXTime
   let miliEpoc = floor $ currTime * 1000 :: Int
@@ -112,13 +117,21 @@ setupCollectionDb conn = do
 
   let htmlTemplates = takeWhile (\case (Nothing, Nothing) -> False; _ -> True) (uncurry zip $ join bimap ((++ repeat Nothing) . (<$>) Just) (frontHtmls, backHtmls))
   let defaultTemplate = (fromJust . listToMaybe) (tmplsModel colModelDefault)
-  let templates = if null htmlTemplates then [defaultTemplate] else
-                    zipWith (\idx (frontTemplate, backTemplate) ->
-                        defaultTemplate { qfmtTemplate = maybe (qfmtTemplate defaultTemplate) T.unpack frontTemplate,
-                          afmtTemplate = maybe (afmtTemplate defaultTemplate) T.unpack backTemplate,
-                          nameTemplate = "Panky Template " ++ show idx
-                          }
-                    ) [0 :: Integer ..] htmlTemplates
+  let templates =
+        if null htmlTemplates
+          then [defaultTemplate]
+          else
+            zipWith
+              ( \idx (frontTemplate, backTemplate) ->
+                  defaultTemplate
+                    { qfmtTemplate = maybe (qfmtTemplate defaultTemplate) T.unpack frontTemplate,
+                      afmtTemplate = maybe (afmtTemplate defaultTemplate) T.unpack backTemplate,
+                      nameTemplate = "Panky Template " ++ show idx,
+                      ordTemplate = idx
+                    }
+              )
+              [0 ..]
+              htmlTemplates
 
   let colModels =
         AKM.fromList
@@ -140,31 +153,30 @@ setupCollectionDb conn = do
       modelKeys = read <$> modelKeyTexts :: [Int] -- couldn't get show to wrok here
   let colConf = colMConfDefault {curModelMConf = Just $ T.pack (last modelKeyTexts)}
 
-  liftIO $ execute
-    conn
-    (Query "INSERT INTO col VALUES(?,?,?,?,?,?,?,?,?,?,?,?,?)")
-    ANS.Col
-      { idCol = 1,
-        crtCol = secEpoc,
-        modCol = miliEpoc,
-        scmCol = miliEpoc,
-        verCol = 11,
-        dtyCol = 0, -- All collections generated will be clean
-        usnCol = 0,
-        lsCol = 0, -- last sync time, not important for a new deck
-        confCol = encodeToLazyText colConf, -- config
-        modelsCol = encodeToLazyText colModels,
-        decksCol = "{}",
-        dconfCol = colDConf,
-        tagsCol = "{}" -- todo, investigate how these tags are used (don't think there are any)
-      }
+  liftIO $
+    execute
+      conn
+      (Query "INSERT INTO col VALUES(?,?,?,?,?,?,?,?,?,?,?,?,?)")
+      ANS.Col
+        { idCol = 1,
+          crtCol = secEpoc,
+          modCol = miliEpoc,
+          scmCol = miliEpoc,
+          verCol = 11,
+          dtyCol = 0, -- All collections generated will be clean
+          usnCol = 0,
+          lsCol = 0, -- last sync time, not important for a new deck
+          confCol = encodeToLazyText colConf, -- config
+          modelsCol = encodeToLazyText colModels,
+          decksCol = "{}",
+          dconfCol = colDConf,
+          tagsCol = "{}" -- todo, investigate how these tags are used (don't think there are any)
+        }
   return modelKeys
 
 generateMediaEntry :: (Int, MediaItem) -> IO Entry
 generateMediaEntry (idx, DeckMedia url _) =
-  withBinaryFile url ReadMode $ \h ->
-    BS.hGetContents h >>= return . BL.fromStrict
-    >>= (\x -> toEntry (show idx) . round <$> getPOSIXTime <*> pure x)
+  withBinaryFile url ReadMode $ \h -> toEntry (show idx) . round <$> getPOSIXTime <*> (BL.fromStrict <$> BS.hGetContents h)
 
 writeDbToApkg :: MediaDeck -> T.Text -> FilePath -> PankyApp ()
 writeDbToApkg media colName dbpath = do
@@ -180,9 +192,6 @@ writeDbToApkg media colName dbpath = do
 
 createCollectionDb :: FilePath -> IO Connection
 createCollectionDb dbpath = removeIfExists dbpath *> open dbpath
-
-addCardsToDeck :: Connection -> [Int] -> RenderedDeck -> PankyDeck ()
-addCardsToDeck c modelKeys = mapM_ (addCard (case modelKeys of [key] -> key; _ -> $(todo "To be figured out when we use more than one model")) c)
 
 generateDeck :: Connection -> [Int] -> RenderedDeck -> DeckGenInfo -> IO ()
 generateDeck conn modelKeys renderedDeck genInfo = do
@@ -205,4 +214,16 @@ generateDeck conn modelKeys renderedDeck genInfo = do
           (decodeStrictText $ T.toStrict decksResult)
       appendedDecks = AKM.insert (AK.fromString (show (deckId genInfo))) newDeck decks
   execute conn (Query "UPDATE col SET decks = ?") (Only $ encodeToLazyText appendedDecks)
-  runStateT (addCardsToDeck conn modelKeys renderedDeck) genInfo $> ()
+
+  [[modelsResult :: T.Text]] <- query_ conn (Query "SELECT models FROM col")
+  let models :: Models =
+        fromMaybe
+          (error "Could not read models field from collection DB table")
+          (decodeStrictText $ T.toStrict modelsResult)
+  let templateOrds = map ordTemplate $ tmplsModel $ fromJust $ listToMaybe $ AKM.elems models
+
+  runStateT (do
+        noteIds <- mapM (addNote (case modelKeys of [key] -> key; _ -> $(todo "To be figured out when we use more than one model")) conn) renderedDeck
+        mapM_ (\noteId -> mapM_ (\templateOrd -> addCard noteId templateOrd conn) templateOrds) noteIds
+    ) genInfo $> ()
+

--- a/app/Collection/Generate.hs
+++ b/app/Collection/Generate.hs
@@ -16,18 +16,20 @@ import Data.ByteString qualified as BS
 import Data.Char (chr)
 import Data.FileEmbed (embedDir, embedFile)
 import Data.Functor (($>))
-import Data.Maybe (fromJust, fromMaybe)
+import Data.Maybe (fromJust, fromMaybe, listToMaybe)
 import Data.Text.Lazy qualified as T
 import Data.Text.Lazy.Encoding qualified as TE
 import Data.Time.Clock.POSIX
 import Database.SQLite.Simple
 import System.FilePath ((</>))
 import Types (DeckGenInfo (..), MediaDeck, MediaItem (DeckMedia), PankyDeck, RenderedCard (RCard), RenderedDeck, PankyApp)
-import Types.Anki.JSON (Deck (..), Decks, MConf (..), Model (..), Models)
+import Types.Anki.JSON (Deck (..), Decks, MConf (..), Model (..), Models, Template (..))
 import Types.Anki.SQL as ANS
 import Utils (todo)
 import System.IO (withBinaryFile, IOMode (ReadMode))
-import Types.CLI (PankyConfig(outputDirPConf, cssOverridePConf, cssExtendPConf))
+import Types.CLI (PankyConfig(outputDirPConf, cssOverridePConf, cssExtendPConf, fontTemplateHtmlsPConf, backTemplateHtmlsPConf))
+import Data.Bifunctor.Compat (bimap)
+import Control.Monad (join)
 
 addCard :: Int -> Connection -> RenderedCard -> PankyDeck ()
 addCard modelId conn (RCard front back tags) = do
@@ -90,23 +92,33 @@ setupCollectionDb conn = do
         commands -> reverse commands
   mapM_ (liftIO . execute_ conn . Query . T.toStrict) queryString
 
-  let colMConfDefault = fromJust $ (decode (fromJust $ lookup "default-anki-json/conf.json" dataFiles) :: Maybe MConf)
-  let colModelDefault = fromJust $ (decode (fromJust $ lookup "default-anki-json/models.json" dataFiles) :: Maybe Model)
+  let colMConfDefault = fromJust (decode (fromJust $ lookup "default-anki-json/conf.json" dataFiles) :: Maybe MConf)
+  let colModelDefault = fromJust (decode (fromJust $ lookup "default-anki-json/models.json" dataFiles) :: Maybe Model)
   let colDConf = TE.decodeUtf8 $ fromJust $ lookup "default-anki-json/dconf.json" dataFiles
   let latexPre = TE.decodeUtf8 $ fromJust $ lookup "latex/preamble.tex" dataFiles
   let latexPost = TE.decodeUtf8 $ fromJust $ lookup "latex/postamble.tex" dataFiles
 
-  -- this is so ugly becuase it relies on logic which is obfuscated all the way in the main file.
   overrideCss <- gets cssOverridePConf
   extendCss <- gets cssExtendPConf
-  let cardCSS = if overrideCss /= "" then
-                      overrideCss
-                    else
-                      (TE.decodeUtf8 $ fromJust $ lookup "css/card.css" dataFiles) <> "\n" <> extendCss
+  let cardCSS = (if overrideCss /= "" then overrideCss else TE.decodeUtf8 (fromJust $ lookup "css/card.css" dataFiles))
+                  <> "\n" <> extendCss
 
   currTime <- liftIO getPOSIXTime
   let miliEpoc = floor $ currTime * 1000 :: Int
       secEpoc = floor currTime :: Int
+
+  frontHtmls <- gets fontTemplateHtmlsPConf
+  backHtmls <- gets backTemplateHtmlsPConf
+
+  let htmlTemplates = takeWhile (\case (Nothing, Nothing) -> False; _ -> True) (uncurry zip $ join bimap ((++ repeat Nothing) . (<$>) Just) (frontHtmls, backHtmls))
+  let defaultTemplate = (fromJust . listToMaybe) (tmplsModel colModelDefault)
+  let templates = if null htmlTemplates then [defaultTemplate] else
+                    zipWith (\idx (frontTemplate, backTemplate) ->
+                        defaultTemplate { qfmtTemplate = maybe (qfmtTemplate defaultTemplate) T.unpack frontTemplate,
+                          afmtTemplate = maybe (afmtTemplate defaultTemplate) T.unpack backTemplate,
+                          nameTemplate = "Panky Template " ++ show idx
+                          }
+                    ) [0 :: Integer ..] htmlTemplates
 
   let colModels =
         AKM.fromList
@@ -117,7 +129,8 @@ setupCollectionDb conn = do
                   latexPreModel = Just latexPre,
                   latexPostModel = Just latexPost,
                   modModel = Just secEpoc,
-                  typeModel = Just 0
+                  typeModel = Just 0,
+                  tmplsModel = templates
                 }
             )
           ] ::

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -10,7 +10,7 @@ import Data.ByteString qualified as BS
 import Data.Default (def)
 import Data.Functor (($>))
 import Data.List (intercalate)
-import Data.Maybe (fromMaybe)
+import Data.Maybe (fromMaybe, listToMaybe)
 import Data.Text qualified as TS
 import Data.Text.Encoding (decodeUtf8')
 import Data.Text.Lazy qualified as T
@@ -140,7 +140,6 @@ constructDeckTree path prefList =
     True -> constructDeckTree' path prefList
     False -> return [InputFile path (DPos prefList)]
 
-type ArgumentDescription = String
 
 showHelp :: [Char]
 showHelp =
@@ -149,6 +148,7 @@ showHelp =
    in (intercalate "\n" . map entryToDescription) (filter notHelp parsePankyOption)
   where notHelp = (/= Flag Help) . fst . snd
 
+type ArgumentDescription = String
 parsePankyOption :: [(String, (PankyOption, ArgumentDescription))]
 parsePankyOption =
   [ ("-version", (Flag Version, versionDescription)),
@@ -158,8 +158,10 @@ parsePankyOption =
     ("-name", (Opt DeckName, nameDescription)),
     ("-output", (Opt OutputDir, outputDescription)),
     ("o", (Opt OutputDir, outputDescription)),
-    ("-css", (Opt CSSExtend, extendCssDescription)),
-    ("+css", (Opt CSSOverride, overrideCssDescription)),
+    ("+css", (Opt CssExtend, extendCssDescription)),
+    ("-css", (Opt CssOverride, overrideCssDescription)),
+    ("-template-front", (Opt TemplateFrontHtml, templateDescription "front")),
+    ("-template-back", (Opt TemplateBackHtml, templateDescription "back")),
     ("-help", (Flag Help, showHelp)),
     ("h", (Flag Help, showHelp))
   ]
@@ -170,6 +172,7 @@ parsePankyOption =
     outputDescription = "Set the output directory"
     extendCssDescription = "Extend the default CSS"
     overrideCssDescription = "Override the default CSS"
+    templateDescription side = "Specify the " <> side <> " html template for the nth template in the Panky model, where n corresponds to the number of times this argument has been used."
 
 parseArgs :: [String] -> [PankyArg]
 parseArgs [] = []
@@ -196,26 +199,25 @@ interpretAsTextOrReadFile rawTextOrFilePath =
 
 constructPankyConfFromArgs :: [PankyArg] -> IO PankyConfig
 constructPankyConfFromArgs opts = do
-  outputDir <- makeAbsolute $ T.unpack $ case [dir | POpt OutputDir dir <- opts] of
-    [] -> "."
-    (dir : _) -> dir
-  -- refactor to be more idiomatic
-  cssExtendRaw <- case [argVal | POpt CSSExtend argVal <- opts] of
-    [] -> pure ""
-    (cssExtendArgVal : _) -> interpretAsTextOrReadFile cssExtendArgVal
-  cssOverrideRaw <- case [argVal | POpt CSSOverride argVal <- opts] of
-    [] -> pure ""
-    (cssOverrideArgVal : _) -> interpretAsTextOrReadFile cssOverrideArgVal
-  when
-    (cssExtendRaw /= "" && cssOverrideRaw /= "")
-    $ error
-      "Cannot extend the default CSS and override the default CSS simultaneously"
+  outputDir <- makeAbsolute $ maybe "." T.unpack (getFirstMatchingKwargText OutputDir)
+  cssExtendRaw <- maybe (pure (T.pack "")) interpretAsTextOrReadFile (getFirstMatchingKwargText CssExtend)
+  cssOverrideRaw <- maybe (pure (T.pack "")) interpretAsTextOrReadFile (getFirstMatchingKwargText CssOverride)
+  fontTemplateHtmlRaws <- mapM interpretAsTextOrReadFile (getAlltMatchingKwargTexts TemplateFrontHtml)
+  backTemplateHtmlRaws <- mapM interpretAsTextOrReadFile (getAlltMatchingKwargTexts TemplateBackHtml)
   return $
     PankyConfig
       { outputDirPConf = outputDir,
         cssExtendPConf = cssExtendRaw,
-        cssOverridePConf = cssOverrideRaw
+        cssOverridePConf = cssOverrideRaw,
+        fontTemplateHtmlsPConf = fontTemplateHtmlRaws,
+        backTemplateHtmlsPConf = backTemplateHtmlRaws
       }
+  where
+    getAlltMatchingKwargTexts :: PankyKWarg -> [T.Text]
+    getAlltMatchingKwargTexts kwargToMatch = [text | POpt kwarg text <- opts, kwargToMatch == kwarg]
+
+    getFirstMatchingKwargText :: PankyKWarg -> Maybe T.Text
+    getFirstMatchingKwargText = listToMaybe . getAlltMatchingKwargTexts
 
 useage :: String
 useage = "anki-pany [flags/options] input"

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -4,8 +4,8 @@
 
 import Collection.Generate
 import Collection.Utils (handleMeta)
-import Control.Monad.State (MonadIO(liftIO), StateT(runStateT), modify, runState, State)
-import Control.Monad (when, filterM, foldM)
+import Control.Monad (filterM, foldM, when)
+import Control.Monad.State (MonadIO (liftIO), State, StateT (runStateT), modify, runState)
 import Data.ByteString qualified as BS
 import Data.Default (def)
 import Data.Functor (($>))
@@ -119,8 +119,7 @@ constructDeckTree' path prefList = do
   paths <- listDirectory path
   specialFiles <-
     filterM
-      ( \fp -> doesDirectoryExist (path </> fp) >>= (return . not)
-      )
+      (\fp -> doesDirectoryExist (path </> fp) >>= (return . not))
       [p | p <- paths, case p of ('.' : _) -> True; _nonSpecial -> False]
 
   filesToIgnore <- if ".pankyignore" `elem` specialFiles then LTO.readFile (path </> ".pankyignore") >>= (return . T.lines) else pure []
@@ -140,15 +139,16 @@ constructDeckTree path prefList =
     True -> constructDeckTree' path prefList
     False -> return [InputFile path (DPos prefList)]
 
-
 showHelp :: [Char]
 showHelp =
   let longestFlag = foldr max 0 $ map (length . fst) parsePankyOption
       entryToDescription = (\(arg, desc) -> replicate (longestFlag - length arg) ' ' <> "-" <> arg <> ": " <> desc) . fmap snd
    in (intercalate "\n" . map entryToDescription) (filter notHelp parsePankyOption)
-  where notHelp = (/= Flag Help) . fst . snd
+  where
+    notHelp = (/= Flag Help) . fst . snd
 
 type ArgumentDescription = String
+
 parsePankyOption :: [(String, (PankyOption, ArgumentDescription))]
 parsePankyOption =
   [ ("-version", (Flag Version, versionDescription)),
@@ -248,8 +248,7 @@ main = do
 
   trees <-
     mapM
-      ( \sourcePath -> ColDir sourcePath <$> constructDeckTree sourcePath []
-      )
+      (\sourcePath -> ColDir sourcePath <$> constructDeckTree sourcePath [])
       inputSources
 
   when (null trees) $

--- a/app/Types/Anki/JSON.hs
+++ b/app/Types/Anki/JSON.hs
@@ -4,6 +4,7 @@ module Types.Anki.JSON
     Model (..),
     Models,
     MConf (..),
+    Template (..),
   )
 where
 

--- a/app/Types/CLI.hs
+++ b/app/Types/CLI.hs
@@ -4,9 +4,9 @@ module Types.CLI
     PankyOption (Flag, Opt),
     DeckPos (DPos),
     PankyFlag (Verbose, Version, Help),
-    PankyKWarg (DeckName, OutputDir, CSSExtend, CSSOverride),
+    PankyKWarg (DeckName, OutputDir, CssExtend, CssOverride, TemplateFrontHtml, TemplateBackHtml),
     CollectionDir (ColDir),
-    PankyConfig (PankyConfig, outputDirPConf, cssExtendPConf, cssOverridePConf),
+    PankyConfig (PankyConfig, outputDirPConf, cssExtendPConf, cssOverridePConf, fontTemplateHtmlsPConf, backTemplateHtmlsPConf),
   )
 where
 
@@ -50,8 +50,10 @@ data PankyFlag
 data PankyKWarg
   = DeckName
   | OutputDir
-  | CSSExtend
-  | CSSOverride
+  | CssExtend
+  | CssOverride
+  | TemplateFrontHtml
+  | TemplateBackHtml
   deriving (Eq, Show)
 
 -- | Used as a type to distinguish between flags and keyword arguments.
@@ -74,5 +76,7 @@ data PankyArg where
 data PankyConfig = PankyConfig
   { outputDirPConf :: FilePath,
     cssExtendPConf :: T.Text,
-    cssOverridePConf :: T.Text
+    cssOverridePConf :: T.Text,
+    fontTemplateHtmlsPConf :: [T.Text],
+    backTemplateHtmlsPConf :: [T.Text]
   }

--- a/data/default-anki-json/models.json
+++ b/data/default-anki-json/models.json
@@ -35,7 +35,7 @@
     "latexPre": null,
     "latexsvg": false,
     "mod": null,
-    "name": "Panky Default",
+    "name": "Panky",
     "req": [
         [
             0,
@@ -49,7 +49,7 @@
     "tags": [],
     "tmpls": [
         {
-            "name": "Card 1",
+            "name": "Panky Card",
             "qfmt": "<div class=\"card\"><div class=\"question\">{{Question}}</div></div>",
             "afmt": "<div class=\"card\"><div class=\"question\">{{Question}}</div><hr><div class=\"answer\">{{Answer}}</div></div>",
             "ord": 0,

--- a/data/default-anki-json/models.json
+++ b/data/default-anki-json/models.json
@@ -35,16 +35,8 @@
     "latexPre": null,
     "latexsvg": false,
     "mod": null,
-    "name": "Panky",
-    "req": [
-        [
-            0,
-            "all",
-            [
-                0
-            ]
-        ]
-    ],
+    "name": "Panky Default",
+    "req": [],
     "sortf": 0,
     "tags": [],
     "tmpls": [


### PR DESCRIPTION
This PR adds the following flags to anki-panky

`--template-front`
`--template-back`

These both take either the path to a file or an html string to override the
standard anki template we use.

KNOWN BUG: because of a bug in my argument parser, you must pass the arguments
as `--template-front='<div class="blah">my template</div>'` as opposed to
`--template-front='<div class="blah">my template</div>'` because of a bug in my
argument parser which will be fixed
