### PR TITLE
Fail hard on parsing error and allow blocks to have trailing horizontal rules

### DIFF
--- a/app/CardParser/Parser.hs
+++ b/app/CardParser/Parser.hs
@@ -3,11 +3,11 @@ module CardParser.Parser (parseCards) where
 import CardParser.ExtCard (extendedCard)
 import CardParser.SimpleCard (simpleCard)
 import Control.Applicative (Alternative (many), (<|>))
-import Text.Pandoc (Block)
+import Text.Pandoc (Block, Block(HorizontalRule))
 import Types.Parser
 
 parseAll :: Parser a -> [Block] -> [a]
-parseAll p bs = [a | (a, []) <- parse p bs]
+parseAll p bs = [a | (a, rest) <- parse p bs, all (== HorizontalRule) rest]
 
 cards :: Parser [Card]
 cards = many (extendedCard <|> simpleCard)

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -81,9 +81,8 @@ handleDeck' conn modelKeys (InputFile path deckPrefix) = do
   (normalisedDoc, mediaFiles) <- normaliseAndExtractMedia doc path
   renderedDeck <- renderPandocAsDecks normalisedDoc
   (_, genInfo) <- runStateT (handleMeta doc deckPrefix) genInfoDefault
-  if null renderedDeck
-    then print ("Skipping file " ++ path ++ " as it failed to parse its cards") $> []
-    else generateDeck conn modelKeys renderedDeck genInfo $> mediaFiles
+  when (null renderedDeck) $ putStrLn ("Failed to render file `" ++ "`. Aborting... deck only partially created") *> exitFailure
+  generateDeck conn modelKeys renderedDeck genInfo $> mediaFiles
 
 dbPath :: IO FilePath
 dbPath = do


### PR DESCRIPTION
Currently if we have the following file:

```markdown
---
name: Test
---

--------------------------------------------------------------------------------

Q1?

. . .

A1.

--------------------------------------------------------------------------------
```

Then silently skip that file and render the other files. Honestly i can barely
remember the defined behaviour for multiple inputs but fuck it. Making a nice
cli interface is actually hard.

This change exits failure on parsing failure and also allows the end of a file /
block to have many horizontal rules.
